### PR TITLE
Fixing inheritance to EntityExtractor

### DIFF
--- a/MSRTEntityExtractor.py
+++ b/MSRTEntityExtractor.py
@@ -28,7 +28,7 @@ from rasa.nlu.extractors.extractor import EntityExtractor
 
 logger = logging.getLogger(__name__)
 
-class MSRTExtractor(Component):
+class MSRTExtractor(EntityExtractor):
     """
        Entity Extractor built using Microsoft's Recognizers Text Package.
     


### PR DESCRIPTION
This was causing an issue when running rasa.test because Rasa checks all the extractors and MSRTExtractor was not in the dictionary.